### PR TITLE
README: Usage example fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import { install, XSLTProcessor } from 'xslt-ts';
 // xsltString: string of xslt file contents
 // output: output DOM model
 install(new DOMParserImpl(), new XMLSerializerImpl(), new DOMImplementationImpl());
-const processor = new XSLTProcessorImpl();
+const processor = new XSLTProcessor();
 
 processor.importStylesheet(xmlParse(xsltString));
 const output = processor.transformToDocument(xmlParse(xmlString));

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ npm install jsdom
 import { DOMImplementationImpl, DOMParserImpl, XMLSerializerImpl } from 'xmldom-ts';
 import { install, xsltProcess, xmlParse } from 'xslt-ts';
 
+install(new DOMParserImpl(), new XMLSerializerImpl(), new DOMImplementationImpl());
+
 // xmlString: string of xml file contents
 // xsltString: string of xslt file contents
 // outXmlString: output xml string.
-install(new DOMParserImpl(), new XMLSerializerImpl(), new DOMImplementationImpl());
 const outXmlString = xsltProcess(xmlParse(xmlString), xmlParse(xsltString));
 ```
 
@@ -53,10 +54,6 @@ const outXmlString = xsltProcess(xmlParse(xmlString), xmlParse(xsltString));
 ```typescript
 import { DOMImplementationImpl, DOMParserImpl, XMLSerializerImpl } from 'xmldom-ts';
 import { install, XSLTProcessor } from 'xslt-ts';
-
-// xmlString: string of xml file contents
-// xsltString: string of xslt file contents
-// output: output DOM model
 const parser = new DOMParserImpl();
 const serializer = new XMLSerializerImpl();
 const dom = new DOMImplementationImpl();
@@ -64,6 +61,9 @@ const dom = new DOMImplementationImpl();
 install(parser, serializer, dom);
 const processor = new XSLTProcessor();
 
+// xmlString: string of xml file contents
+// xsltString: string of xslt file contents
+// output: output DOM model
 processor.importStylesheet(parser.parseFromString(xsltString, 'text/xml'));
 const output = processor.transformToDocument(parser.parseFromString(xmlString, 'text/xml'));
 ```

--- a/README.md
+++ b/README.md
@@ -52,16 +52,20 @@ const outXmlString = xsltProcess(xmlParse(xmlString), xmlParse(xsltString));
 
 ```typescript
 import { DOMImplementationImpl, DOMParserImpl, XMLSerializerImpl } from 'xmldom-ts';
-import { install, xmlParse, XSLTProcessor } from 'xslt-ts';
+import { install, XSLTProcessor } from 'xslt-ts';
 
 // xmlString: string of xml file contents
 // xsltString: string of xslt file contents
 // output: output DOM model
-install(new DOMParserImpl(), new XMLSerializerImpl(), new DOMImplementationImpl());
+const parser = new DOMParserImpl();
+const serializer = new XMLSerializerImpl();
+const dom = new DOMImplementationImpl();
+
+install(parser, serializer, dom);
 const processor = new XSLTProcessor();
 
-processor.importStylesheet(xmlParse(xsltString));
-const output = processor.transformToDocument(xmlParse(xmlString));
+processor.importStylesheet(parser.parseFromString(xsltString, 'text/xml'));
+const output = processor.transformToDocument(parser.parseFromString(xmlString, 'text/xml'));
 ```
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -39,14 +39,17 @@ npm install jsdom
 
 ```typescript
 import { DOMImplementationImpl, DOMParserImpl, XMLSerializerImpl } from 'xmldom-ts';
-import { install, xsltProcess, xmlParse } from 'xslt-ts';
+import { install, xsltProcess } from 'xslt-ts';
+const parser = new DOMParserImpl();
+const serializer = new XMLSerializerImpl();
+const dom = new DOMImplementationImpl();
 
-install(new DOMParserImpl(), new XMLSerializerImpl(), new DOMImplementationImpl());
+install(parser, serializer, dom);
 
 // xmlString: string of xml file contents
 // xsltString: string of xslt file contents
 // outXmlString: output xml string.
-const outXmlString = xsltProcess(xmlParse(xmlString), xmlParse(xsltString));
+const outXmlString = xsltProcess(parser.parseFromString(xmlString, 'text/xml'), parser.parseFromString(xsltString, 'text/xml'));
 ```
 
 ## another type of usage:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const outXmlString = xsltProcess(xmlParse(xmlString), xmlParse(xsltString));
 
 ```typescript
 import { DOMImplementationImpl, DOMParserImpl, XMLSerializerImpl } from 'xmldom-ts';
-import { install, XSLTProcessor } from 'xslt-ts';
+import { install, xmlParse, XSLTProcessor } from 'xslt-ts';
 
 // xmlString: string of xml file contents
 // xsltString: string of xslt file contents


### PR DESCRIPTION
Fixup to use the imported `XSLTProcessor` object name.